### PR TITLE
We are grepping the wrong string here.

### DIFF
--- a/flash/system/xbin/check-kalihostapd
+++ b/flash/system/xbin/check-kalihostapd
@@ -1,6 +1,5 @@
-if [[ -n $(ps |grep '/usr/local/bin/hostapd') ]]; then
+if [[ -n $(ps |grep '/usr/sbin/hostapd') ]]; then
     echo "1"
 else
     echo "0"
 fi
-


### PR DESCRIPTION
The string `'/usr/local/bin/hostapd'` should be `'/usr/sbin/hostapd'`

The hostapd swicht will work correctly now.
