### PR TITLE
Add a couple of packages that were missing on Kali linux 1.0.9a (64bit) ...

### DIFF
--- a/build-deps.sh
+++ b/build-deps.sh
@@ -3,7 +3,8 @@ apt-get install -y git-core gnupg flex bison gperf libesd0-dev build-essential \
 zip curl libncurses5-dev zlib1g-dev libncurses5-dev gcc-multilib g++-multilib \
 parted kpartx debootstrap pixz qemu-user-static abootimg cgpt vboot-kernel-utils \
 vboot-utils uboot-mkimage bc lzma lzop automake autoconf m4 dosfstools pixz rsync \
-schedtool git dosfstools e2fsprogs device-tree-compiler ccache dos2unix
+schedtool git dosfstools e2fsprogs device-tree-compiler ccache dos2unix abootimg \
+debootstrap qemu-user-static
 MACHINE_TYPE=`uname -m`
 if [ ${MACHINE_TYPE} == 'x86_64' ]; then
     dpkg --add-architecture i386


### PR DESCRIPTION
There were a few packages missing from Kali Linux 1.0.9a (64bit) that were necessary to build NetHunter for the Oneplus One.  I suspect most of these packages would be necessary for most device builds.
