### PR TITLE
Added sleep in hid-all.py to give cmd enough time to open

### DIFF
--- a/utils/hid/hid-all.py
+++ b/utils/hid/hid-all.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 import argparse
 import sys
+import time
 sys.path.append("/sdcard/files/modules/")
 from keyseed import *
 
@@ -45,18 +46,23 @@ def read_file(filename):
 # HID Command Options
 if (args.wincmd):
 	wincmd(locale)
+	time.sleep(5)
 	read_file(filename = "/sdcard/files/hid-cmd.conf")
 elif (args.win7cmd):
 	win7cmd_elevated(locale)
+	time.sleep(5)
 	read_file(filename = "/sdcard/files/hid-cmd.conf")
 elif (args.win8cmd):
 	win8cmd_elevated(locale)
+	time.sleep(5)
 	read_file(filename = "/sdcard/files/hid-cmd.conf")
 elif (args.win7_met):
 	win7cmd_elevated(locale)
+	time.sleep(5)
 	read_file(filename = "/sdcard/files/rev-met")
 elif (args.win8_met):
 	win8cmd_elevated(locale)
+	time.sleep(5)
 	read_file(filename = "/sdcard/files/rev-met")
 
 # All finished - Hit enter


### PR DESCRIPTION
When testing on my Win7 machine, I encountered an issue where the command prompt didn't open before the powershell string was sent. It appeared as though nothing was typed into the command prompt.

Fixed indentation issue, and took binkybear's advice in using `time.sleep(5)` instead of `print "sleep 2"`.