### PR TITLE
update build-deps.sh for ubuntu 14.04 builds

### DIFF
--- a/build-deps.sh
+++ b/build-deps.sh
@@ -2,7 +2,7 @@
 utils/safe-apt-get install -y git-core gnupg flex bison gperf libesd0-dev build-essential \
 zip curl libncurses5-dev zlib1g-dev libncurses5-dev gcc-multilib g++-multilib \
 parted kpartx debootstrap pixz qemu-user-static abootimg cgpt vboot-kernel-utils \
-vboot-utils uboot-mkimage bc lzma lzop automake autoconf m4 dosfstools rsync \
+vboot-utils u-boot-tools bc lzma lzop automake autoconf m4 dosfstools rsync \
 schedtool git e2fsprogs device-tree-compiler ccache dos2unix
 
 if [ $? -eq 001 ]; then


### PR DESCRIPTION
uboot-mkimage has been deprecated by u-boot-tools in Ubuntu 14.04.