### PR TITLE
Fix bug with -u and can build zip and uninstaller

### DIFF
--- a/AnyKernel2/README.md
+++ b/AnyKernel2/README.md
@@ -17,7 +17,7 @@ python build.py -d hammerhead --marshmallow -k
 ```
 Force download all third party apps:
 ```sh
-python build.py --forcedownload
+python build.py --forcedown
 ```
 Building the uninstaller:
 ```sh

--- a/AnyKernel2/build.py
+++ b/AnyKernel2/build.py
@@ -357,10 +357,10 @@ def main():
         device = args.device
         # Add developer information to Anykernel2
         regexanykernel(device)
-    elif not args.device:
+    elif not args.device and not args.uninstaller:
         print('No arguments supplied.  Try -h or --help')
         exit(0)
-    else:
+    elif args.device:
         print('Device %s not found devices.cfg' % args.device)
         exit(0)
 
@@ -435,7 +435,8 @@ def main():
         zipfilename = 'nethunter-uninstaller'
         zip('tmp_out', zipfilename, 'uninstaller')
         print('Created uninstaller: ', zipfilename + '.zip')
-        exit(0)
+        if not args.device:
+            exit(0)
 
     if os.path.isdir('supersu') and not suzipfile:
         supersu(True)


### PR DESCRIPTION
Now, you can build the update zip and the uninstaller in one command, and also it will not ask you for a device name if you specify the -u switch.
Could you please verify that I didn't introduced any bugs